### PR TITLE
Add opacity setting to line mode

### DIFF
--- a/lib/highlight-column-element.coffee
+++ b/lib/highlight-column-element.coffee
@@ -67,7 +67,7 @@ class HighlightColumnView extends HTMLDivElement
 
   opacity: ->
     if @isLineMode()
-      0.3
+      atom.config.get('highlight-column.opacity') ? 0.15
     else
       atom.config.get('highlight-column.opacity') ? 0.15
 


### PR DESCRIPTION
I'm not sure why the opacity for the line-mode was hardcoded, 
but I think a lot of users prefer to change its value.